### PR TITLE
Fix grammar and spelling mistakes in the "Why Pion" page.

### DIFF
--- a/content/en/why-pion.md
+++ b/content/en/why-pion.md
@@ -2,15 +2,15 @@
 tags: ["webrtc", "pion"]
 title: "Why Pion"
 ---
-'Why would I use Pion' this is the first question we get asked by potential users, and it is a great one. Learning new software is an investment, as developers we know how frustrating it can be when you make the wrong choice.
+'Why would I use Pion?' This is the first question we get asked by potential users, and it is a great one. Learning new software is an investment, as developers we know how frustrating it can be when you make the wrong choice.
 
-The answer is different depending on your needs. However it seems to always come down to a few major reasons. Here is what drives Pion, and why we think you should give us a try.
+The answer is different depending on your needs. However, it seems to always come down to a few major reasons. Here is what drives Pion, and why we think you should give us a try.
 
 ## Written in Go
 Go is one of the keys to our success. If you are a Go developer these all might be old news to you, but if you haven't used Go before you might not know all the perks it offers.
 
 #### Portable
-With one command you can compile your Pion application for any supported platform. In one program (with no platform specific code) you can target FreeBSD, Android, macOS and your Browser (WASM)
+With one command you can compile your Pion application for any supported platform. In one program (with no platform-specific code) you can target FreeBSD, Android, macOS, and your Browser (WASM)
 
 #### Simple
 The Pion code base was written with simplicity in mind. Any Go developer should be able to read it and just worry about learning WebRTC, not the nuances of the language.
@@ -19,14 +19,14 @@ The Pion code base was written with simplicity in mind. Any Go developer should 
 Don't waste time worrying about tooling or formatting. Go solves all of this, worry just about building your great idea.
 
 ## Community Owned
-Pion is a community owned project, there is no corporation behind it, no BDFL and every developer has an equal vote. We don't have private issues, and our roadmap is driven by our users.
+Pion is a community-owned project, there is no corporation behind it, no BDFL and every developer has an equal vote. We don't have private issues, and our roadmap is driven by our users.
 
 The only thing required to land in master is an approval from another developer. We move fast, and you are never blocked waiting for someone who is on vacation.
 
-We make it a priority to be welcoming to newcomers, and some of our best improvements has been from fresh eyes. We have an active [Slack](../../slack), and try our best to help everyone.
+We make it a priority to be welcoming to newcomers, and some of our best improvements have been from fresh eyes. We have an active [Slack](../../slack), and try our best to help everyone.
 
 ## Diverse Userbase
-Our users include large companies, startups and hobbyists who are just building interesting hacks. Pion is a great tool to build mobile applications, WebRTC servers and everything in between.
+Our users include large companies, startups and hobbyists who are just building interesting hacks. Pion is a great tool to build mobile applications, WebRTC servers, and everything in between.
 
 People are building things and solving problems with Pion that we never knew about before. By serving everyone we have made it more robust, and flexible for all.
 
@@ -36,9 +36,9 @@ Everything we built is packaged into small blocks. We encourage you to read, lea
 WebRTC can be confusing, and we have found that splitting things into small blocks makes it a lot easier for others to learn and contribute.
 
 ## Spec Compliance
-We try really hard to implement WebRTC correctly. Divergence causes lots of pain, sometimes we make mistakes but our goal is always to implement WebRTC and not be 'WebRTC-like'
+We try really hard to implement WebRTC correctly. Divergence causes lots of pain. Sometimes we make mistakes, but our goal is always to implement WebRTC and not be 'WebRTC-like'
 
 ## More Than Just Software
 Pion isn't just about building software, but also educating people and furthering what we can build with WebRTC. Someday better software may come, but hopefully our biggest impact will be creating innovation and fostering a great community.
 
-We have created [WebRTC for the Curious](https://webrtcforthecurious.com) and are documenting everything we learned from building a WebRTC implementation from scratch. We want to pass on everything we learned, our long term goal is to see a WebRTC implememntation in every language.
+We have created [WebRTC for the Curious](https://webrtcforthecurious.com) and are documenting everything we learned from building a WebRTC implementation from scratch. We want to pass on everything we learned. Our long-term goal is to see a WebRTC implementation in every language.


### PR DESCRIPTION
#### Description
I noticed a misspelling of "implementation" as "implememntation", so I fixed that and other mistakes.
